### PR TITLE
Bump @maxday/account-number-validator from 1.0.1 to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -770,9 +770,9 @@
       }
     },
     "@maxday/account-number-validator": {
-      "version": "1.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@maxday/account-number-validator/1.0.1/614cabe2189dd8a037ee0133db8e8f0f67eb371840787c1ac03772cf90dc6177",
-      "integrity": "sha512-5YSbHY8bMSaZEtQ6v7gyPi7lLtjIFKUqXmt8D9UQv+eO0PFm74zBgHOe44WIJm/h677+QM2QFmEZfKjNuzNjhw=="
+      "version": "1.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@maxday/account-number-validator/1.0.2/dabe181afea657c936eca21aa0934315fc5bd22bc7d2c2a9ec20045040aa1272",
+      "integrity": "sha512-dzWbWLm0N82kx0Rc1EQHDunE8+24RpoM4THqmdEGf/ZPngV1o+UVHf/luzPK01SQKljlubqtV2FIGXUeBvz0fg=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@maxday/account-number-validator": "1.0.1",
+    "@maxday/account-number-validator": "1.0.2",
     "connect-datadog": "0.0.9",
     "dd-trace": "^0.32.0",
     "express": "^4.17.1"


### PR DESCRIPTION
Bumps [@maxday/account-number-validator]() from 1.0.1 to 1.0.2.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>